### PR TITLE
Updated to support Spring Boot 2 and Spring Cloud Finchley

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.9.RELEASE</version>
+        <version>2.0.3.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -48,14 +48,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Edgware.RELEASE</spring-cloud.version>
+        <spring-cloud.version>Finchley.RELEASE</spring-cloud.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-eureka-server</artifactId>
+            <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava-reactive-streams</artifactId>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/test/java/at/twinformatics/eureka/adapter/consul/controller/ServiceControllerTest.java
+++ b/src/test/java/at/twinformatics/eureka/adapter/consul/controller/ServiceControllerTest.java
@@ -41,7 +41,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.cloud.netflix.rx.SingleReturnValueHandler;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -85,8 +84,7 @@ public class ServiceControllerTest {
         executorService1 = Executors.newSingleThreadExecutor();
         serviceChangeDetector.reset();
 
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-                .setCustomReturnValueHandlers(new SingleReturnValueHandler()).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
     @After


### PR DESCRIPTION
First off, this is a really useful project, thanks for creating it.
I've been using it for a while now, and it has worked perfectly.

I was just testing it out with Spring Boot 2 and Spring Cloud Finchley.RELEASE, and noticed that the /v1/catalog/ endpoints were not working.

Some minor pom updates were all that were required to get it working.
See: https://stackoverflow.com/questions/42748775/spring-webflux-and-observable-responses-not-working

`org.springframework.cloud.netflix.rx.SingleReturnValueHandler` is no longer present in Spring Cloud Netflix, but it doesn't seem to be required when using rxjava-reactive-streams.

Any suggestions for changes, please let me know.