### PR TITLE
Add mapping metadata of service (registered in Eureka) to ServiceMeta…

### DIFF
--- a/src/main/java/at/twinformatics/eureka/adapter/consul/mapper/MetadataMapper.java
+++ b/src/main/java/at/twinformatics/eureka/adapter/consul/mapper/MetadataMapper.java
@@ -1,0 +1,10 @@
+package at.twinformatics.eureka.adapter.consul.mapper;
+
+import java.util.Map;
+
+public interface MetadataMapper {
+
+    Map<String, String> extractNodeMetadata(Map<String, String> instanceMetaData);
+
+    Map<String, String> extractServiceMetadata(Map<String, String> instanceMetaData);
+}

--- a/src/main/java/at/twinformatics/eureka/adapter/consul/mapper/NodeMetadataMapper.java
+++ b/src/main/java/at/twinformatics/eureka/adapter/consul/mapper/NodeMetadataMapper.java
@@ -1,0 +1,44 @@
+package at.twinformatics.eureka.adapter.consul.mapper;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnProperty(name = "eurekaConsulAdapter.useNodeMeta", havingValue = "true")
+@Component
+public class NodeMetadataMapper implements MetadataMapper {
+
+    private final String nodeMetaPrefix;
+    private Pattern nodeMetaPattern;
+
+    public NodeMetadataMapper(String nodeMetaPrefix) {
+        this.nodeMetaPrefix = nodeMetaPrefix;
+        nodeMetaPattern = Pattern.compile(String.format("^%s.+$", nodeMetaPrefix));
+    }
+
+    @Override
+    public Map<String, String> extractNodeMetadata(@NonNull Map<String, String> instanceMetaData) {
+        return instanceMetaData.entrySet().stream()
+                               .filter(entry -> nodeMetaPattern.matcher(entry.getKey()).matches())
+                               .collect(Collectors.toMap(
+                                   entry -> entry.getKey().substring(nodeMetaPrefix.length())
+                                   , Map.Entry::getValue
+                                   , (oldValue, newValue) -> newValue
+                               ));
+    }
+
+    @Override
+    public Map<String, String> extractServiceMetadata(
+        @NonNull Map<String, String> instanceMetaData) {
+        return instanceMetaData.entrySet().stream()
+                               .filter(e -> !nodeMetaPattern.matcher(e.getKey()).matches())
+                               .collect(Collectors.toMap(
+                                   Map.Entry::getKey
+                                   , Map.Entry::getValue
+                                   , (oldValue, newValue) -> newValue)
+                               );
+    }
+}

--- a/src/main/java/at/twinformatics/eureka/adapter/consul/mapper/ServiceMetadataMapper.java
+++ b/src/main/java/at/twinformatics/eureka/adapter/consul/mapper/ServiceMetadataMapper.java
@@ -1,0 +1,23 @@
+package at.twinformatics.eureka.adapter.consul.mapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnProperty(name = "eurekaConsulAdapter.useNodeMeta", havingValue = "false",
+                       matchIfMissing = true)
+@Component
+public class ServiceMetadataMapper implements MetadataMapper {
+
+    @Override
+    public Map<String, String> extractNodeMetadata(@NonNull Map<String, String> instanceMetaData) {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Map<String, String> extractServiceMetadata(@NonNull Map<String, String> instanceMetaData) {
+        return instanceMetaData;
+    }
+}

--- a/src/main/java/at/twinformatics/eureka/adapter/consul/model/Service.java
+++ b/src/main/java/at/twinformatics/eureka/adapter/consul/model/Service.java
@@ -45,6 +45,9 @@ public class Service {
     @JsonProperty("ServiceAddress")
     private String serviceAddress;
 
+    @JsonProperty("ServiceName")
+    private String serviceName;
+
     @JsonProperty("ServiceID")
     private String serviceID;
 
@@ -53,6 +56,9 @@ public class Service {
 
     @JsonProperty("NodeMeta")
     private Map<String, String> nodeMeta;
+
+    @JsonProperty("ServiceMeta")
+    private Map<String, String> serviceMeta;
 
     // will be empty, eureka does not have the concept of service tags
     @JsonProperty("ServiceTags")


### PR DESCRIPTION
Firstly I would like to thank you for creating this library. It's very helpful.
Several months ago we've started to monitoring our applications by **Prometheus**. 
Most of the time **Consul** has been used as Discover Service but two weeks ago we've decided to use **Eureka** with **Eureka Consul Adapter** as Discovery Service. Our services are registered with additional metadata and we use them in **relabeling** phase of **Prometheus**. During **relabeling** phase we use following meta label `__meta_consul_service_metadata_<key>`. With **Consul** it works correctly but with **Eureka** with **Eureka Consul Adapter** it doesn't work as we expected. We noticed that metadata associated with service (registered in **Eureka**) appears as **NodeMeta** instead of **ServiceMeta**. In our opinion metadata of service registered in **Eureka** should appear as **ServiceMeta** because these metadata are associated with service, not with node of Consul.

We've made changes that make metadata of service (registered in **Eureka**) appears as **ServiceMeta**.

For backward compatibility we introduce following properties:
- `eurekaConsulAdapter.useNodeMeta` : boolean (default: false)
- `eurekaConsulAdapter.nodeMetaPrefix` : String (default: "")

Possible scenarios of usage:

 1
- `eurekaConsulAdapter.useNodeMeta` is not set or is set to `false` 
- `eurekaConsulAdapter.nodeMetaPrefix` in this case is not used
each metadata of service (registered in **Eureka**) appears as **ServiceMeta**, **NodeMeta** map is empty

2
- `eurekaConsulAdapter.useNodeMeta` is set to `true`
- `eurekaConsulAdapter.nodeMetaPrefix` is not set (default value) or is set to `""` (empty string)
each metadata of service (registered in **Eureka**) appears as **NodeMeta**, **ServiceMeta** map is empty

3
- `eurekaConsulAdapter.useNodeMeta` is set to `true`
- `eurekaConsulAdapter.nodeMetaPrefix` is set to e.g. `nodeMeta_`
each metadata of service (registered in **Eureka**) is filtered according to the following rules:
  - metadata which key begins with `nodeMeta_` is moved to **NodeMeta** map (during moving prefix is removed **nodeMeta_k1** -> **k1**)
  - metadata which key not begins with `nodeMeta_` is moved to **ServiceMeta** map
