### PR TITLE
spring boot expose endpoints by using a different HTTP port

### DIFF
--- a/prometheus-sample-config.yml
+++ b/prometheus-sample-config.yml
@@ -39,3 +39,6 @@ scrape_configs:
         action: keep
       - source_labels: ['__meta_consul_service']
         target_label: job
+      - source_labels: ['__meta_consul_address', '__meta_consul_service_metadata_management_port']
+        separator: ':'
+        target_label: __address__


### PR DESCRIPTION
When spring boot expose endpoints by using a different HTTP port --management.server.port, The `__address__ `label should be relabeled.